### PR TITLE
GROW-940 Handle redirects to current URL after portlet actions

### DIFF
--- a/modules/badge/BadgeTypeEditor/bnd.bnd
+++ b/modules/badge/BadgeTypeEditor/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Grow Badge Type Editor
 Bundle-SymbolicName: com.liferay.grow.gamification.badges.editor
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Export-Package: com.liferay.grow.gamification.badges.editor.constants

--- a/modules/badge/BadgeTypeEditor/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/badge/BadgeTypeEditor/src/main/resources/META-INF/resources/view.jsp
@@ -75,7 +75,9 @@ page import="com.liferay.portal.kernel.util.DateUtil" %>
 	</div>
 </div>
 
-<portlet:actionURL name="addBadgeType" var="addBadgeTypeURL" />
+<portlet:actionURL name="addBadgeType" var="addBadgeTypeURL" >
+	<portlet:param name="redirect" value="<%= themeDisplay.getURLCurrent() %>" />
+</portlet:actionURL>
 
 <c:if test="${themeDisplay.isSignedIn() == true}">
 	<div aria-hidden="true" class="modal" id="badgeTypeModal" role="dialog" style="display:none; z-index" tabindex="-1">

--- a/modules/badge/SimpleBadgePortlet/bnd.bnd
+++ b/modules/badge/SimpleBadgePortlet/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Grow Simple Badge Portlet
 Bundle-SymbolicName: com.liferay.grow.gamification.badges.portlet
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Export-Package: com.liferay.grow.gamification.badges.portlet.constants

--- a/modules/badge/SimpleBadgePortlet/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/badge/SimpleBadgePortlet/src/main/resources/META-INF/resources/view.jsp
@@ -10,7 +10,9 @@ List<BadgeType> badgeTypes = (List<BadgeType>)request.getAttribute("BADGE_TYPES"
 List<User> users = (List<User>)request.getAttribute("USER_LIST");
 %>
 <% if (themeDisplay.isSignedIn())  { %>
-<portlet:actionURL name="addBadge" var="addBadgeURL" />
+<portlet:actionURL name="addBadge" var="addBadgeURL" >
+	<portlet:param name="redirect" value="<%= themeDisplay.getURLCurrent() %>" />
+</portlet:actionURL>
 
 <div class="container">
 	<div class="row custom">

--- a/modules/badge/UserBadgesDisplay/bnd.bnd
+++ b/modules/badge/UserBadgesDisplay/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Grow User Badges Display
 Bundle-SymbolicName: com.liferay.grow.gamification.badges.display
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Export-Package: com.liferay.grow.gamification.badges.display.constants

--- a/modules/badge/UserBadgesDisplay/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/badge/UserBadgesDisplay/src/main/resources/META-INF/resources/view.jsp
@@ -12,7 +12,9 @@ long userId = 0;
 String userName = "";
 %>
 
-<portlet:actionURL name="addBadge" var="addBadgeURL" />
+<portlet:actionURL name="addBadge" var="addBadgeURL">
+	<portlet:param name="redirect" value="<%= themeDisplay.getURLCurrent() %>" />
+</portlet:actionURL>
 
 <div class="modal" id="badgeModal" tabindex="-1" role="dialog" aria-hidden="true" style="display:none; z-index">
 	<div class="flex">


### PR DESCRIPTION
Currently portlet actions adds their parameters to URLs on clicking on action buttons. If those URLs are called again, the actions will be triggered again. 

With this change, after the action performed, the browser location is set back to the original one, where we started the action from.