### PR TITLE
GROW-945 Fix sender's username in system notifications

### DIFF
--- a/modules/badge/BadgeNotificationPortlet/bnd.bnd
+++ b/modules/badge/BadgeNotificationPortlet/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Grow Badge Notification Portlet
 Bundle-SymbolicName: com.liferay.grow.gamificaiton.badges.notification
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Export-Package:\
 	com.liferay.grow.gamificaiton.badges.notification.constants,\
 	com.liferay.grow.gamification.badges.notification,\

--- a/modules/badge/BadgeNotificationPortlet/src/main/java/com/liferay/grow/gamification/badges/notification/BadgeNotificationHandler.java
+++ b/modules/badge/BadgeNotificationPortlet/src/main/java/com/liferay/grow/gamification/badges/notification/BadgeNotificationHandler.java
@@ -6,7 +6,6 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.notifications.BaseUserNotificationHandler;
 import com.liferay.portal.kernel.notifications.UserNotificationFeedEntry;
@@ -64,15 +63,6 @@ public class BadgeNotificationHandler extends BaseUserNotificationHandler {
 			ServiceContext serviceContext)
 		throws Exception {
 
-		String userName = _UKNOWN_USER;
-
-		User user = _userLocalService.fetchUser(
-			userNotificationEvent.getUserId());
-
-		if (Validator.isNotNull(user)) {
-			userName = user.getFullName();
-		}
-
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			userNotificationEvent.getPayload());
 
@@ -81,6 +71,9 @@ public class BadgeNotificationHandler extends BaseUserNotificationHandler {
 
 		String reason = jsonObject.getString(
 			BadgeNotificationPortletKeys.BADGE_COMMENT);
+
+		String userName = jsonObject.getString(
+			BadgeNotificationPortletKeys.BADGE_SENDER);
 
 		if (Validator.isNull(reason)) {
 			reason = "";

--- a/modules/badge/BadgeNotificationPortlet/src/main/java/com/liferay/grow/gamification/badges/notification/constants/BadgeNotificationPortletKeys.java
+++ b/modules/badge/BadgeNotificationPortlet/src/main/java/com/liferay/grow/gamification/badges/notification/constants/BadgeNotificationPortletKeys.java
@@ -7,6 +7,8 @@ public class BadgeNotificationPortletKeys {
 
 	public static final String BADGE_COMMENT = "BADGE_COMMENT";
 
+	public static final String BADGE_SENDER = "BADGE_SENDER";
+
 	public static final String BADGE_TYPE = "BADGE_TYPE";
 
 	public static final String BadgeNotification = "badgenotification";

--- a/modules/badge/Badges/Badges-service/bnd.bnd
+++ b/modules/badge/Badges/Badges-service/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Grow Badges Service
 Bundle-SymbolicName: com.liferay.grow.gamification.service
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Liferay-Require-SchemaVersion: 1.0.0
 Liferay-Service: true

--- a/modules/badge/Badges/Badges-service/src/main/java/com/liferay/grow/gamification/service/impl/BadgeLocalServiceImpl.java
+++ b/modules/badge/Badges/Badges-service/src/main/java/com/liferay/grow/gamification/service/impl/BadgeLocalServiceImpl.java
@@ -272,6 +272,8 @@ public class BadgeLocalServiceImpl extends BadgeLocalServiceBaseImpl {
 		payloadJSON.put(BadgeNotificationPortletKeys.BADGE_TYPE, badgeType);
 		payloadJSON.put(
 			BadgeNotificationPortletKeys.BADGE_COMMENT, badge.getDescription());
+		payloadJSON.put(
+				BadgeNotificationPortletKeys.BADGE_SENDER, badge.getUserName());
 
 		UserNotificationEvent userNotificationEvent =
 			UserNotificationEventLocalServiceUtil.createUserNotificationEvent(


### PR DESCRIPTION
Hi @moltam89 

I had to change the logic how we can pass the badge sender's name to the notification event. I tested this way and now it seems to be correct for me.